### PR TITLE
Pdf Image style fix

### DIFF
--- a/src/components/Pdf/Pdf.scss
+++ b/src/components/Pdf/Pdf.scss
@@ -6,8 +6,8 @@
   flex-direction: column;
   justify-content: center;
   img {
-    max-width: 280px;
-    margin: 0 1rem;
+    max-width: 320px;
+    margin: 0 1.5rem;
   }
   .Button {
     @include primaryBtn;
@@ -48,6 +48,7 @@
     flex-direction: row;
     img {
       max-width: 450px;
+      margin: 0 1rem;
     }
     .Button {
       margin: 1rem 0;

--- a/src/components/Pdf/Pdf.scss
+++ b/src/components/Pdf/Pdf.scss
@@ -6,7 +6,7 @@
   flex-direction: column;
   justify-content: center;
   img {
-    max-width: 320px;
+    max-width: min(100%, 320px);
     margin: 0 1.5rem;
   }
   .Button {


### PR DESCRIPTION
Actualiza los tamaños maximos y margenes para que la imagen de los pdf quede centrada en mobile, sin sobrepasar el tamaño de la pagina.